### PR TITLE
Bump argocd to v1

### DIFF
--- a/bootstrap-unofficial/charts/argocd/split-templates-FIXME.sh
+++ b/bootstrap-unofficial/charts/argocd/split-templates-FIXME.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# unofficial bash strict mode
+set -euo pipefail
+IFS=$'\n\t'
+
+# run from any directory (no symlink allowed)
+CURRENT_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)
+cd ${CURRENT_PATH}
+
+##############################
+
+function reset_templates {
+  local TEMPLATES_PATH="templates/"
+
+  rm -fr ${TEMPLATES_PATH}
+  mkdir -p ${TEMPLATES_PATH}
+  # FIXME update relative paths
+  cd ${TEMPLATES_PATH}
+}
+
+# https://argoproj.github.io/argo-cd/getting_started/#1-install-argo-cd
+# param #1: <output_name>
+function download_install_chart {
+  local OUTPUT_NAME=$1
+  local URL="https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml"
+
+  curl -s -o ${OUTPUT_NAME} ${URL}
+}
+
+# param #1: <file_name>
+# param #2: <prefix>
+function split_by_resource {
+  local FILE_NAME=$1
+  local PREFIX=$2
+  
+  case "$(uname -s)" in
+    Darwin)
+      # macOS
+      split -p "---" -a 3 ${FILE_NAME} ${PREFIX}
+      ;;
+    Linux)
+      # Ubuntu
+      echo "FIXME on Linux" && exit 1
+
+      # multi-character separator not supported
+      sed -i'.tmp' -e 's/---/!/g' ${FILE_NAME}
+      split -t '!' -a 3 ${FILE_NAME} ${PREFIX}
+      ;;
+    *)
+      echo "unknown OS" && exit 1
+      ;;
+  esac
+}
+
+# param #1: <file_name>
+function extract_file_name {
+  local FILE_NAME=$1
+
+  # extract second column from lines starting with "kind"
+  # prefix upper case with dash
+  # convert upper to lower case
+  # add file extension
+  awk '/^kind/ { print $2 }' $FILE_NAME |
+    sed 's/\(.\)\([A-Z]\)/\1-\2/g' |
+    tr '[:upper:]' '[:lower:]' |
+    awk '{ print $1".yaml" }'
+}
+
+# param #1: <prefix>
+function append_to_resource {
+  local PREFIX=$1
+
+  # append content to file of the same resource type
+  for FILE in ${PREFIX}*; do
+    FILE_NAME=$(extract_file_name $FILE)
+    cat ${FILE} >> ${FILE_NAME}
+  done
+}
+
+# param #1: <suffix>
+function remove_comment {
+  local SUFFIX=$1
+
+  find . -type f -name '*.yaml' -exec sed -i ${SUFFIX} 's/^.*DO NOT EDIT$/---/' {} \;
+}
+
+function main {
+  local INSTALL_FILE="install.yaml"
+  local PREFIX="argo-cd-"
+  local SUFFX=".orig"
+
+  reset_templates
+  download_install_chart ${INSTALL_FILE}
+  split_by_resource ${INSTALL_FILE} ${PREFIX}
+  append_to_resource ${PREFIX}
+  remove_comment '.orig'
+
+  # cleanup
+  rm -fr ${INSTALL_FILE} ${PREFIX} *${SUFFX}
+}
+
+main

--- a/bootstrap-unofficial/charts/argocd/split-templates.sh
+++ b/bootstrap-unofficial/charts/argocd/split-templates.sh
@@ -1,103 +1,42 @@
+
 #!/bin/bash
 
-# unofficial bash strict mode
-set -euo pipefail
-IFS=$'\n\t'
+PREFIX="argo-cd-"
+INSTALL_FILE="install.yaml"
+TEMPLATES_PATH="templates/"
 
-# run from any directory (no symlink allowed)
-CURRENT_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)
-cd ${CURRENT_PATH}
-
-##############################
-
-function reset_templates {
-  local TEMPLATES_PATH="templates/"
-
-  rm -fr ${TEMPLATES_PATH}
-  mkdir -p ${TEMPLATES_PATH}
-  # FIXME update relative paths
-  cd ${TEMPLATES_PATH}
-}
+cd ${TEMPLATES_PATH}
+# remove all files except the one starting with number
+rm [^0-9]*
 
 # https://argoproj.github.io/argo-cd/getting_started/#1-install-argo-cd
-# param #1: <output_name>
-function download_install_chart {
-  local OUTPUT_NAME=$1
-  local URL="https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml"
+curl -o ${INSTALL_FILE} https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 
-  curl -s -o ${OUTPUT_NAME} ${URL}
-}
+# split by resource type
+split -p "---" -a 3 ${INSTALL_FILE} ${PREFIX}
 
-# param #1: <file_name>
-# param #2: <prefix>
-function split_by_resource {
-  local FILE_NAME=$1
-  local PREFIX=$2
-  
-  case "$(uname -s)" in
-    Darwin)
-      # macOS
-      split -p "---" -a 3 ${FILE_NAME} ${PREFIX}
-      ;;
-    Linux)
-      # Ubuntu
-      echo "FIXME on Linux" && exit 1
-
-      # multi-character separator not supported
-      sed -i'.tmp' -e 's/---/!/g' ${FILE_NAME}
-      split -t '!' -a 3 ${FILE_NAME} ${PREFIX}
-      ;;
-    *)
-      echo "unknown OS" && exit 1
-      ;;
-  esac
-}
-
-# param #1: <file_name>
 function extract_file_name {
-  local FILE_NAME=$1
-
+  local FILE=$1
   # extract second column from lines starting with "kind"
-  # prefix upper case with dash
+  # convert upper case to dash
   # convert upper to lower case
   # add file extension
-  awk '/^kind/ { print $2 }' $FILE_NAME |
+  awk '/^kind/ { print $2 }' $FILE |
     sed 's/\(.\)\([A-Z]\)/\1-\2/g' |
     tr '[:upper:]' '[:lower:]' |
     awk '{ print $1".yaml" }'
 }
 
-# param #1: <prefix>
-function append_to_resource {
-  local PREFIX=$1
+# append content to file of the same resource type
+for FILE in ${PREFIX}*; do
+  FILE_NAME=$(extract_file_name $FILE)
+  cat $FILE >> $FILE_NAME
+done
 
-  # append content to file of the same resource type
-  for FILE in ${PREFIX}*; do
-    FILE_NAME=$(extract_file_name $FILE)
-    cat ${FILE} >> ${FILE_NAME}
-  done
-}
+# remove comment
+find . -type f -name '*.yaml' -exec sed -i '.orig' 's/^.*DO NOT EDIT$/---/' {} \;
 
-# param #1: <suffix>
-function remove_comment {
-  local SUFFIX=$1
-
-  find . -type f -name '*.yaml' -exec sed -i ${SUFFIX} 's/^.*DO NOT EDIT$/---/' {} \;
-}
-
-function main {
-  local INSTALL_FILE="install.yaml"
-  local PREFIX="argo-cd-"
-  local SUFFX=".orig"
-
-  reset_templates
-  download_install_chart ${INSTALL_FILE}
-  split_by_resource ${INSTALL_FILE} ${PREFIX}
-  append_to_resource ${PREFIX}
-  remove_comment
-
-  # cleanup
-  rm -fr ${INSTALL_FILE} ${PREFIX} *${SUFFX}
-}
-
-main
+# cleanup
+rm ${INSTALL_FILE}
+rm ${PREFIX}*
+rm *".orig"

--- a/bootstrap-unofficial/charts/argocd/templates/custom-resource-definition.yaml
+++ b/bootstrap-unofficial/charts/argocd/templates/custom-resource-definition.yaml
@@ -15,6 +15,1335 @@ spec:
     - app
     - apps
   scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata: {}
+        operation:
+          description: Operation contains requested operation parameters.
+          properties:
+            sync:
+              description: SyncOperation contains sync operation details.
+              properties:
+                dryRun:
+                  description: DryRun will perform a `kubectl apply --dry-run` without
+                    actually performing the sync
+                  type: boolean
+                prune:
+                  description: Prune deletes resources that are no longer tracked
+                    in git
+                  type: boolean
+                resources:
+                  description: Resources describes which resources to sync
+                  items:
+                    description: SyncOperationResource contains resources to sync.
+                    properties:
+                      group:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                  type: array
+                revision:
+                  description: Revision is the git revision in which to sync the application
+                    to. If omitted, will use the revision specified in app spec.
+                  type: string
+                source:
+                  description: ApplicationSource contains information about github
+                    repository, path within repository and target application environment.
+                  properties:
+                    directory:
+                      properties:
+                        jsonnet:
+                          description: ApplicationSourceJsonnet holds jsonnet specific
+                            options
+                          properties:
+                            extVars:
+                              description: ExtVars is a list of Jsonnet External Variables
+                              items:
+                                description: JsonnetVar is a jsonnet variable
+                                properties:
+                                  code:
+                                    type: boolean
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            tlas:
+                              description: TLAS is a list of Jsonnet Top-level Arguments
+                              items:
+                                description: JsonnetVar is a jsonnet variable
+                                properties:
+                                  code:
+                                    type: boolean
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                          type: object
+                        recurse:
+                          type: boolean
+                      type: object
+                    helm:
+                      description: ApplicationSourceHelm holds helm specific options
+                      properties:
+                        parameters:
+                          description: Parameters are parameters to the helm template
+                          items:
+                            description: HelmParameter is a parameter to a helm template
+                            properties:
+                              name:
+                                description: Name is the name of the helm parameter
+                                type: string
+                              value:
+                                description: Value is the value for the helm parameter
+                                type: string
+                            type: object
+                          type: array
+                        valueFiles:
+                          description: ValuesFiles is a list of Helm value files to
+                            use when generating a template
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    ksonnet:
+                      description: ApplicationSourceKsonnet holds ksonnet specific
+                        options
+                      properties:
+                        environment:
+                          description: Environment is a ksonnet application environment
+                            name
+                          type: string
+                        parameters:
+                          description: Parameters are a list of ksonnet component
+                            parameter override values
+                          items:
+                            description: KsonnetParameter is a ksonnet component parameter
+                            properties:
+                              component:
+                                type: string
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                      type: object
+                    kustomize:
+                      description: ApplicationSourceKustomize holds kustomize specific
+                        options
+                      properties:
+                        imageTags:
+                          description: ImageTags are kustomize 1.0 image tag overrides
+                          items:
+                            description: KustomizeImageTag is a kustomize image tag
+                            properties:
+                              name:
+                                description: Name is the name of the image (e.g. nginx)
+                                type: string
+                              value:
+                                description: Value is the value for the new tag (e.g.
+                                  1.8.0)
+                                type: string
+                            type: object
+                          type: array
+                        images:
+                          description: Images are kustomize 2.0 image overrides
+                          items:
+                            type: string
+                          type: array
+                        namePrefix:
+                          description: NamePrefix is a prefix appended to resources
+                            for kustomize apps
+                          type: string
+                      type: object
+                    path:
+                      description: Path is a directory path within the repository
+                        containing a
+                      type: string
+                    plugin:
+                      description: ApplicationSourcePlugin holds config management
+                        plugin specific options
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                    repoURL:
+                      description: RepoURL is the git repository URL of the application
+                        manifests
+                      type: string
+                    targetRevision:
+                      description: Environment is a ksonnet application environment
+                        name TargetRevision defines the commit, tag, or branch in
+                        which to sync the application to. If omitted, will sync to
+                        HEAD
+                      type: string
+                  required:
+                  - repoURL
+                  - path
+                  type: object
+                syncStrategy:
+                  description: SyncStrategy controls the manner in which a sync is
+                    performed
+                  properties:
+                    apply:
+                      description: SyncStrategyApply uses `kubectl apply` to perform
+                        the apply
+                      properties:
+                        force:
+                          description: Force indicates whether or not to supply the
+                            --force flag to `kubectl apply`. The --force flag deletes
+                            and re-create the resource, when PATCH encounters conflict
+                            and has retried for 5 times.
+                          type: boolean
+                      type: object
+                    hook:
+                      description: SyncStrategyHook will perform a sync using hooks
+                        annotations. If no hook annotation is specified falls back
+                        to `kubectl apply`.
+                      properties:
+                        SyncStrategyApply:
+                          description: SyncStrategyApply uses `kubectl apply` to perform
+                            the apply
+                          properties:
+                            force:
+                              description: Force indicates whether or not to supply
+                                the --force flag to `kubectl apply`. The --force flag
+                                deletes and re-create the resource, when PATCH encounters
+                                conflict and has retried for 5 times.
+                              type: boolean
+                          type: object
+                      type: object
+                  type: object
+              type: object
+          type: object
+        spec:
+          description: ApplicationSpec represents desired application state. Contains
+            link to repository with application definition and additional parameters
+            link definition revision.
+          properties:
+            destination:
+              description: ApplicationDestination contains deployment destination
+                information
+              properties:
+                namespace:
+                  description: Namespace overrides the environment namespace value
+                    in the ksonnet app.yaml
+                  type: string
+                server:
+                  description: Server overrides the environment server value in the
+                    ksonnet app.yaml
+                  type: string
+              type: object
+            ignoreDifferences:
+              description: IgnoreDifferences controls resources fields which should
+                be ignored during comparison
+              items:
+                description: ResourceIgnoreDifferences contains resource filter and
+                  list of json paths which should be ignored during comparison with
+                  live state.
+                properties:
+                  group:
+                    type: string
+                  jsonPointers:
+                    items:
+                      type: string
+                    type: array
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - group
+                - kind
+                - jsonPointers
+                type: object
+              type: array
+            project:
+              description: Project is a application project name. Empty name means
+                that application belongs to 'default' project.
+              type: string
+            source:
+              description: ApplicationSource contains information about github repository,
+                path within repository and target application environment.
+              properties:
+                directory:
+                  properties:
+                    jsonnet:
+                      description: ApplicationSourceJsonnet holds jsonnet specific
+                        options
+                      properties:
+                        extVars:
+                          description: ExtVars is a list of Jsonnet External Variables
+                          items:
+                            description: JsonnetVar is a jsonnet variable
+                            properties:
+                              code:
+                                type: boolean
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        tlas:
+                          description: TLAS is a list of Jsonnet Top-level Arguments
+                          items:
+                            description: JsonnetVar is a jsonnet variable
+                            properties:
+                              code:
+                                type: boolean
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                      type: object
+                    recurse:
+                      type: boolean
+                  type: object
+                helm:
+                  description: ApplicationSourceHelm holds helm specific options
+                  properties:
+                    parameters:
+                      description: Parameters are parameters to the helm template
+                      items:
+                        description: HelmParameter is a parameter to a helm template
+                        properties:
+                          name:
+                            description: Name is the name of the helm parameter
+                            type: string
+                          value:
+                            description: Value is the value for the helm parameter
+                            type: string
+                        type: object
+                      type: array
+                    valueFiles:
+                      description: ValuesFiles is a list of Helm value files to use
+                        when generating a template
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                ksonnet:
+                  description: ApplicationSourceKsonnet holds ksonnet specific options
+                  properties:
+                    environment:
+                      description: Environment is a ksonnet application environment
+                        name
+                      type: string
+                    parameters:
+                      description: Parameters are a list of ksonnet component parameter
+                        override values
+                      items:
+                        description: KsonnetParameter is a ksonnet component parameter
+                        properties:
+                          component:
+                            type: string
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - name
+                        - value
+                        type: object
+                      type: array
+                  type: object
+                kustomize:
+                  description: ApplicationSourceKustomize holds kustomize specific
+                    options
+                  properties:
+                    imageTags:
+                      description: ImageTags are kustomize 1.0 image tag overrides
+                      items:
+                        description: KustomizeImageTag is a kustomize image tag
+                        properties:
+                          name:
+                            description: Name is the name of the image (e.g. nginx)
+                            type: string
+                          value:
+                            description: Value is the value for the new tag (e.g.
+                              1.8.0)
+                            type: string
+                        type: object
+                      type: array
+                    images:
+                      description: Images are kustomize 2.0 image overrides
+                      items:
+                        type: string
+                      type: array
+                    namePrefix:
+                      description: NamePrefix is a prefix appended to resources for
+                        kustomize apps
+                      type: string
+                  type: object
+                path:
+                  description: Path is a directory path within the repository containing
+                    a
+                  type: string
+                plugin:
+                  description: ApplicationSourcePlugin holds config management plugin
+                    specific options
+                  properties:
+                    name:
+                      type: string
+                  type: object
+                repoURL:
+                  description: RepoURL is the git repository URL of the application
+                    manifests
+                  type: string
+                targetRevision:
+                  description: Environment is a ksonnet application environment name
+                    TargetRevision defines the commit, tag, or branch in which to
+                    sync the application to. If omitted, will sync to HEAD
+                  type: string
+              required:
+              - repoURL
+              - path
+              type: object
+            syncPolicy:
+              description: SyncPolicy controls when a sync will be performed in response
+                to updates in git
+              properties:
+                automated:
+                  description: SyncPolicyAutomated controls the behavior of an automated
+                    sync
+                  properties:
+                    prune:
+                      description: 'Prune will prune resources automatically as part
+                        of automated sync (default: false)'
+                      type: boolean
+                  type: object
+              type: object
+          required:
+          - source
+          - destination
+          - project
+          type: object
+        status:
+          description: ApplicationStatus contains information about application sync,
+            health status
+          properties:
+            conditions:
+              items:
+                description: ApplicationCondition contains details about current application
+                  condition
+                properties:
+                  message:
+                    description: Message contains human-readable message indicating
+                      details about condition
+                    type: string
+                  type:
+                    description: Type is an application condition type
+                    type: string
+                required:
+                - type
+                - message
+                type: object
+              type: array
+            health:
+              properties:
+                message:
+                  type: string
+                status:
+                  type: string
+              type: object
+            history:
+              items:
+                description: RevisionHistory contains information relevant to an application
+                  deployment
+                properties:
+                  deployedAt: {}
+                  id:
+                    format: int64
+                    type: integer
+                  revision:
+                    type: string
+                  source:
+                    description: ApplicationSource contains information about github
+                      repository, path within repository and target application environment.
+                    properties:
+                      directory:
+                        properties:
+                          jsonnet:
+                            description: ApplicationSourceJsonnet holds jsonnet specific
+                              options
+                            properties:
+                              extVars:
+                                description: ExtVars is a list of Jsonnet External
+                                  Variables
+                                items:
+                                  description: JsonnetVar is a jsonnet variable
+                                  properties:
+                                    code:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              tlas:
+                                description: TLAS is a list of Jsonnet Top-level Arguments
+                                items:
+                                  description: JsonnetVar is a jsonnet variable
+                                  properties:
+                                    code:
+                                      type: boolean
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                            type: object
+                          recurse:
+                            type: boolean
+                        type: object
+                      helm:
+                        description: ApplicationSourceHelm holds helm specific options
+                        properties:
+                          parameters:
+                            description: Parameters are parameters to the helm template
+                            items:
+                              description: HelmParameter is a parameter to a helm
+                                template
+                              properties:
+                                name:
+                                  description: Name is the name of the helm parameter
+                                  type: string
+                                value:
+                                  description: Value is the value for the helm parameter
+                                  type: string
+                              type: object
+                            type: array
+                          valueFiles:
+                            description: ValuesFiles is a list of Helm value files
+                              to use when generating a template
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      ksonnet:
+                        description: ApplicationSourceKsonnet holds ksonnet specific
+                          options
+                        properties:
+                          environment:
+                            description: Environment is a ksonnet application environment
+                              name
+                            type: string
+                          parameters:
+                            description: Parameters are a list of ksonnet component
+                              parameter override values
+                            items:
+                              description: KsonnetParameter is a ksonnet component
+                                parameter
+                              properties:
+                                component:
+                                  type: string
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                        type: object
+                      kustomize:
+                        description: ApplicationSourceKustomize holds kustomize specific
+                          options
+                        properties:
+                          imageTags:
+                            description: ImageTags are kustomize 1.0 image tag overrides
+                            items:
+                              description: KustomizeImageTag is a kustomize image
+                                tag
+                              properties:
+                                name:
+                                  description: Name is the name of the image (e.g.
+                                    nginx)
+                                  type: string
+                                value:
+                                  description: Value is the value for the new tag
+                                    (e.g. 1.8.0)
+                                  type: string
+                              type: object
+                            type: array
+                          images:
+                            description: Images are kustomize 2.0 image overrides
+                            items:
+                              type: string
+                            type: array
+                          namePrefix:
+                            description: NamePrefix is a prefix appended to resources
+                              for kustomize apps
+                            type: string
+                        type: object
+                      path:
+                        description: Path is a directory path within the repository
+                          containing a
+                        type: string
+                      plugin:
+                        description: ApplicationSourcePlugin holds config management
+                          plugin specific options
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      repoURL:
+                        description: RepoURL is the git repository URL of the application
+                          manifests
+                        type: string
+                      targetRevision:
+                        description: Environment is a ksonnet application environment
+                          name TargetRevision defines the commit, tag, or branch in
+                          which to sync the application to. If omitted, will sync
+                          to HEAD
+                        type: string
+                    required:
+                    - repoURL
+                    - path
+                    type: object
+                required:
+                - revision
+                - deployedAt
+                - id
+                - source
+                type: object
+              type: array
+            observedAt: {}
+            operationState:
+              description: OperationState contains information about state of currently
+                performing operation on application.
+              properties:
+                finishedAt: {}
+                message:
+                  description: Message hold any pertinent messages when attempting
+                    to perform operation (typically errors).
+                  type: string
+                operation:
+                  description: Operation contains requested operation parameters.
+                  properties:
+                    sync:
+                      description: SyncOperation contains sync operation details.
+                      properties:
+                        dryRun:
+                          description: DryRun will perform a `kubectl apply --dry-run`
+                            without actually performing the sync
+                          type: boolean
+                        prune:
+                          description: Prune deletes resources that are no longer
+                            tracked in git
+                          type: boolean
+                        resources:
+                          description: Resources describes which resources to sync
+                          items:
+                            description: SyncOperationResource contains resources
+                              to sync.
+                            properties:
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          type: array
+                        revision:
+                          description: Revision is the git revision in which to sync
+                            the application to. If omitted, will use the revision
+                            specified in app spec.
+                          type: string
+                        source:
+                          description: ApplicationSource contains information about
+                            github repository, path within repository and target application
+                            environment.
+                          properties:
+                            directory:
+                              properties:
+                                jsonnet:
+                                  description: ApplicationSourceJsonnet holds jsonnet
+                                    specific options
+                                  properties:
+                                    extVars:
+                                      description: ExtVars is a list of Jsonnet External
+                                        Variables
+                                      items:
+                                        description: JsonnetVar is a jsonnet variable
+                                        properties:
+                                          code:
+                                            type: boolean
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    tlas:
+                                      description: TLAS is a list of Jsonnet Top-level
+                                        Arguments
+                                      items:
+                                        description: JsonnetVar is a jsonnet variable
+                                        properties:
+                                          code:
+                                            type: boolean
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                  type: object
+                                recurse:
+                                  type: boolean
+                              type: object
+                            helm:
+                              description: ApplicationSourceHelm holds helm specific
+                                options
+                              properties:
+                                parameters:
+                                  description: Parameters are parameters to the helm
+                                    template
+                                  items:
+                                    description: HelmParameter is a parameter to a
+                                      helm template
+                                    properties:
+                                      name:
+                                        description: Name is the name of the helm
+                                          parameter
+                                        type: string
+                                      value:
+                                        description: Value is the value for the helm
+                                          parameter
+                                        type: string
+                                    type: object
+                                  type: array
+                                valueFiles:
+                                  description: ValuesFiles is a list of Helm value
+                                    files to use when generating a template
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            ksonnet:
+                              description: ApplicationSourceKsonnet holds ksonnet
+                                specific options
+                              properties:
+                                environment:
+                                  description: Environment is a ksonnet application
+                                    environment name
+                                  type: string
+                                parameters:
+                                  description: Parameters are a list of ksonnet component
+                                    parameter override values
+                                  items:
+                                    description: KsonnetParameter is a ksonnet component
+                                      parameter
+                                    properties:
+                                      component:
+                                        type: string
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                              type: object
+                            kustomize:
+                              description: ApplicationSourceKustomize holds kustomize
+                                specific options
+                              properties:
+                                imageTags:
+                                  description: ImageTags are kustomize 1.0 image tag
+                                    overrides
+                                  items:
+                                    description: KustomizeImageTag is a kustomize
+                                      image tag
+                                    properties:
+                                      name:
+                                        description: Name is the name of the image
+                                          (e.g. nginx)
+                                        type: string
+                                      value:
+                                        description: Value is the value for the new
+                                          tag (e.g. 1.8.0)
+                                        type: string
+                                    type: object
+                                  type: array
+                                images:
+                                  description: Images are kustomize 2.0 image overrides
+                                  items:
+                                    type: string
+                                  type: array
+                                namePrefix:
+                                  description: NamePrefix is a prefix appended to
+                                    resources for kustomize apps
+                                  type: string
+                              type: object
+                            path:
+                              description: Path is a directory path within the repository
+                                containing a
+                              type: string
+                            plugin:
+                              description: ApplicationSourcePlugin holds config management
+                                plugin specific options
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            repoURL:
+                              description: RepoURL is the git repository URL of the
+                                application manifests
+                              type: string
+                            targetRevision:
+                              description: Environment is a ksonnet application environment
+                                name TargetRevision defines the commit, tag, or branch
+                                in which to sync the application to. If omitted, will
+                                sync to HEAD
+                              type: string
+                          required:
+                          - repoURL
+                          - path
+                          type: object
+                        syncStrategy:
+                          description: SyncStrategy controls the manner in which a
+                            sync is performed
+                          properties:
+                            apply:
+                              description: SyncStrategyApply uses `kubectl apply`
+                                to perform the apply
+                              properties:
+                                force:
+                                  description: Force indicates whether or not to supply
+                                    the --force flag to `kubectl apply`. The --force
+                                    flag deletes and re-create the resource, when
+                                    PATCH encounters conflict and has retried for
+                                    5 times.
+                                  type: boolean
+                              type: object
+                            hook:
+                              description: SyncStrategyHook will perform a sync using
+                                hooks annotations. If no hook annotation is specified
+                                falls back to `kubectl apply`.
+                              properties:
+                                SyncStrategyApply:
+                                  description: SyncStrategyApply uses `kubectl apply`
+                                    to perform the apply
+                                  properties:
+                                    force:
+                                      description: Force indicates whether or not
+                                        to supply the --force flag to `kubectl apply`.
+                                        The --force flag deletes and re-create the
+                                        resource, when PATCH encounters conflict and
+                                        has retried for 5 times.
+                                      type: boolean
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                  type: object
+                phase:
+                  description: Phase is the current phase of the operation
+                  type: string
+                startedAt: {}
+                syncResult:
+                  description: SyncOperationResult represent result of sync operation
+                  properties:
+                    resources:
+                      description: Resources holds the sync result of each individual
+                        resource
+                      items:
+                        description: ResourceResult holds the operation result details
+                          of a specific resource
+                        properties:
+                          group:
+                            type: string
+                          hookPhase:
+                            type: string
+                          hookType:
+                            type: string
+                          kind:
+                            type: string
+                          message:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          status:
+                            type: string
+                          version:
+                            type: string
+                        required:
+                        - group
+                        - version
+                        - kind
+                        - namespace
+                        - name
+                        type: object
+                      type: array
+                    revision:
+                      description: Revision holds the git commit SHA of the sync
+                      type: string
+                    source:
+                      description: ApplicationSource contains information about github
+                        repository, path within repository and target application
+                        environment.
+                      properties:
+                        directory:
+                          properties:
+                            jsonnet:
+                              description: ApplicationSourceJsonnet holds jsonnet
+                                specific options
+                              properties:
+                                extVars:
+                                  description: ExtVars is a list of Jsonnet External
+                                    Variables
+                                  items:
+                                    description: JsonnetVar is a jsonnet variable
+                                    properties:
+                                      code:
+                                        type: boolean
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                tlas:
+                                  description: TLAS is a list of Jsonnet Top-level
+                                    Arguments
+                                  items:
+                                    description: JsonnetVar is a jsonnet variable
+                                    properties:
+                                      code:
+                                        type: boolean
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                              type: object
+                            recurse:
+                              type: boolean
+                          type: object
+                        helm:
+                          description: ApplicationSourceHelm holds helm specific options
+                          properties:
+                            parameters:
+                              description: Parameters are parameters to the helm template
+                              items:
+                                description: HelmParameter is a parameter to a helm
+                                  template
+                                properties:
+                                  name:
+                                    description: Name is the name of the helm parameter
+                                    type: string
+                                  value:
+                                    description: Value is the value for the helm parameter
+                                    type: string
+                                type: object
+                              type: array
+                            valueFiles:
+                              description: ValuesFiles is a list of Helm value files
+                                to use when generating a template
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        ksonnet:
+                          description: ApplicationSourceKsonnet holds ksonnet specific
+                            options
+                          properties:
+                            environment:
+                              description: Environment is a ksonnet application environment
+                                name
+                              type: string
+                            parameters:
+                              description: Parameters are a list of ksonnet component
+                                parameter override values
+                              items:
+                                description: KsonnetParameter is a ksonnet component
+                                  parameter
+                                properties:
+                                  component:
+                                    type: string
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                          type: object
+                        kustomize:
+                          description: ApplicationSourceKustomize holds kustomize
+                            specific options
+                          properties:
+                            imageTags:
+                              description: ImageTags are kustomize 1.0 image tag overrides
+                              items:
+                                description: KustomizeImageTag is a kustomize image
+                                  tag
+                                properties:
+                                  name:
+                                    description: Name is the name of the image (e.g.
+                                      nginx)
+                                    type: string
+                                  value:
+                                    description: Value is the value for the new tag
+                                      (e.g. 1.8.0)
+                                    type: string
+                                type: object
+                              type: array
+                            images:
+                              description: Images are kustomize 2.0 image overrides
+                              items:
+                                type: string
+                              type: array
+                            namePrefix:
+                              description: NamePrefix is a prefix appended to resources
+                                for kustomize apps
+                              type: string
+                          type: object
+                        path:
+                          description: Path is a directory path within the repository
+                            containing a
+                          type: string
+                        plugin:
+                          description: ApplicationSourcePlugin holds config management
+                            plugin specific options
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        repoURL:
+                          description: RepoURL is the git repository URL of the application
+                            manifests
+                          type: string
+                        targetRevision:
+                          description: Environment is a ksonnet application environment
+                            name TargetRevision defines the commit, tag, or branch
+                            in which to sync the application to. If omitted, will
+                            sync to HEAD
+                          type: string
+                      required:
+                      - repoURL
+                      - path
+                      type: object
+                  required:
+                  - revision
+                  - source
+                  type: object
+              required:
+              - operation
+              - phase
+              - startedAt
+              type: object
+            reconciledAt: {}
+            resources:
+              items:
+                description: ResourceStatus holds the current sync and health status
+                  of a resource
+                properties:
+                  group:
+                    type: string
+                  health:
+                    properties:
+                      message:
+                        type: string
+                      status:
+                        type: string
+                    type: object
+                  hook:
+                    type: boolean
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  status:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              type: array
+            sourceType:
+              type: string
+            summary:
+              properties:
+                externalURLs:
+                  description: ExternalURLs holds all external URLs of application
+                    child resources.
+                  items:
+                    type: string
+                  type: array
+                images:
+                  description: Images holds all images of application child resources.
+                  items:
+                    type: string
+                  type: array
+              type: object
+            sync:
+              description: SyncStatus is a comparison result of application spec and
+                deployed application.
+              properties:
+                comparedTo:
+                  description: ComparedTo contains application source and target which
+                    was used for resources comparison
+                  properties:
+                    destination:
+                      description: ApplicationDestination contains deployment destination
+                        information
+                      properties:
+                        namespace:
+                          description: Namespace overrides the environment namespace
+                            value in the ksonnet app.yaml
+                          type: string
+                        server:
+                          description: Server overrides the environment server value
+                            in the ksonnet app.yaml
+                          type: string
+                      type: object
+                    source:
+                      description: ApplicationSource contains information about github
+                        repository, path within repository and target application
+                        environment.
+                      properties:
+                        directory:
+                          properties:
+                            jsonnet:
+                              description: ApplicationSourceJsonnet holds jsonnet
+                                specific options
+                              properties:
+                                extVars:
+                                  description: ExtVars is a list of Jsonnet External
+                                    Variables
+                                  items:
+                                    description: JsonnetVar is a jsonnet variable
+                                    properties:
+                                      code:
+                                        type: boolean
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                tlas:
+                                  description: TLAS is a list of Jsonnet Top-level
+                                    Arguments
+                                  items:
+                                    description: JsonnetVar is a jsonnet variable
+                                    properties:
+                                      code:
+                                        type: boolean
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                              type: object
+                            recurse:
+                              type: boolean
+                          type: object
+                        helm:
+                          description: ApplicationSourceHelm holds helm specific options
+                          properties:
+                            parameters:
+                              description: Parameters are parameters to the helm template
+                              items:
+                                description: HelmParameter is a parameter to a helm
+                                  template
+                                properties:
+                                  name:
+                                    description: Name is the name of the helm parameter
+                                    type: string
+                                  value:
+                                    description: Value is the value for the helm parameter
+                                    type: string
+                                type: object
+                              type: array
+                            valueFiles:
+                              description: ValuesFiles is a list of Helm value files
+                                to use when generating a template
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        ksonnet:
+                          description: ApplicationSourceKsonnet holds ksonnet specific
+                            options
+                          properties:
+                            environment:
+                              description: Environment is a ksonnet application environment
+                                name
+                              type: string
+                            parameters:
+                              description: Parameters are a list of ksonnet component
+                                parameter override values
+                              items:
+                                description: KsonnetParameter is a ksonnet component
+                                  parameter
+                                properties:
+                                  component:
+                                    type: string
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                          type: object
+                        kustomize:
+                          description: ApplicationSourceKustomize holds kustomize
+                            specific options
+                          properties:
+                            imageTags:
+                              description: ImageTags are kustomize 1.0 image tag overrides
+                              items:
+                                description: KustomizeImageTag is a kustomize image
+                                  tag
+                                properties:
+                                  name:
+                                    description: Name is the name of the image (e.g.
+                                      nginx)
+                                    type: string
+                                  value:
+                                    description: Value is the value for the new tag
+                                      (e.g. 1.8.0)
+                                    type: string
+                                type: object
+                              type: array
+                            images:
+                              description: Images are kustomize 2.0 image overrides
+                              items:
+                                type: string
+                              type: array
+                            namePrefix:
+                              description: NamePrefix is a prefix appended to resources
+                                for kustomize apps
+                              type: string
+                          type: object
+                        path:
+                          description: Path is a directory path within the repository
+                            containing a
+                          type: string
+                        plugin:
+                          description: ApplicationSourcePlugin holds config management
+                            plugin specific options
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        repoURL:
+                          description: RepoURL is the git repository URL of the application
+                            manifests
+                          type: string
+                        targetRevision:
+                          description: Environment is a ksonnet application environment
+                            name TargetRevision defines the commit, tag, or branch
+                            in which to sync the application to. If omitted, will
+                            sync to HEAD
+                          type: string
+                      required:
+                      - repoURL
+                      - path
+                      type: object
+                  required:
+                  - source
+                  - destination
+                  type: object
+                revision:
+                  type: string
+                status:
+                  type: string
+              required:
+              - status
+              - comparedTo
+              - revision
+              type: object
+          type: object
+      type: object
   version: v1alpha1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -33,4 +1362,104 @@ spec:
     - appproj
     - appprojs
   scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata: {}
+        spec:
+          description: AppProjectSpec is the specification of an AppProject
+          properties:
+            clusterResourceWhitelist:
+              description: ClusterResourceWhitelist contains list of whitelisted cluster
+                level resources
+              items: {}
+              type: array
+            description:
+              description: Description contains optional project description
+              type: string
+            destinations:
+              description: Destinations contains list of destinations available for
+                deployment
+              items:
+                description: ApplicationDestination contains deployment destination
+                  information
+                properties:
+                  namespace:
+                    description: Namespace overrides the environment namespace value
+                      in the ksonnet app.yaml
+                    type: string
+                  server:
+                    description: Server overrides the environment server value in
+                      the ksonnet app.yaml
+                    type: string
+                type: object
+              type: array
+            namespaceResourceBlacklist:
+              description: NamespaceResourceBlacklist contains list of blacklisted
+                namespace level resources
+              items: {}
+              type: array
+            roles:
+              description: Roles are user defined RBAC roles associated with this
+                project
+              items:
+                description: ProjectRole represents a role that has access to a project
+                properties:
+                  description:
+                    description: Description is a description of the role
+                    type: string
+                  groups:
+                    description: Groups are a list of OIDC group claims bound to this
+                      role
+                    items:
+                      type: string
+                    type: array
+                  jwtTokens:
+                    description: JWTTokens are a list of generated JWT tokens bound
+                      to this role
+                    items:
+                      description: JWTToken holds the issuedAt and expiresAt values
+                        of a token
+                      properties:
+                        exp:
+                          format: int64
+                          type: integer
+                        iat:
+                          format: int64
+                          type: integer
+                      required:
+                      - iat
+                      type: object
+                    type: array
+                  name:
+                    description: Name is a name for this role
+                    type: string
+                  policies:
+                    description: Policies Stores a list of casbin formated strings
+                      that define access policies for the role in the project
+                    items:
+                      type: string
+                    type: array
+                required:
+                - name
+                type: object
+              type: array
+            sourceRepos:
+              description: SourceRepos contains list of git repository URLs which
+                can be used for deployment
+              items:
+                type: string
+              type: array
+          type: object
+      type: object
   version: v1alpha1

--- a/bootstrap-unofficial/charts/argocd/templates/deployment.yaml
+++ b/bootstrap-unofficial/charts/argocd/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - "20"
         - --operation-processors
         - "10"
-        image: argoproj/argocd:v0.12.3
+        image: argoproj/argocd:v1.0.0
         imagePullPolicy: Always
         name: argocd-application-controller
         ports:
@@ -72,7 +72,7 @@ spec:
         - cp
         - /usr/local/bin/argocd-util
         - /shared
-        image: argoproj/argocd:v0.12.3
+        image: argoproj/argocd:v1.0.0
         imagePullPolicy: Always
         name: copyutil
         volumeMounts:
@@ -135,8 +135,13 @@ spec:
         - argocd-repo-server
         - --redis
         - argocd-redis:6379
-        image: argoproj/argocd:v0.12.3
+        image: argoproj/argocd:v1.0.0
         imagePullPolicy: Always
+        livenessProbe:
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          tcpSocket:
+            port: 8081
         name: argocd-repo-server
         ports:
         - containerPort: 8081
@@ -167,15 +172,16 @@ spec:
       containers:
       - command:
         - argocd-server
-        # TODO allow http
-        #- --insecure
         - --staticassets
         - /shared/app
-        # TODO change base path
-        #- --basehref
-        #- /argocd
-        image: argoproj/argocd:v0.12.3
+        image: argoproj/argocd:v1.0.0
         imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 30
         name: argocd-server
         ports:
         - containerPort: 8080
@@ -195,7 +201,7 @@ spec:
         - -r
         - /app
         - /shared
-        image: argoproj/argocd-ui:v0.12.3
+        image: argoproj/argocd-ui:v1.0.0
         imagePullPolicy: Always
         name: ui
         volumeMounts:


### PR DESCRIPTION
Let me know what do you think about this, my approach was that those "unofficial charts" should be autogenerated until we don't fix the one with the requirement approach.
Please have a look at the `split-templates.sh` script. I had to revert it cos I broke it while I was testing it on Ubuntu and I need to investigate it further.