### PR TITLE
add crd to ambassador whitelist

### DIFF
--- a/applications/templates/ambassador/project.yaml
+++ b/applications/templates/ambassador/project.yaml
@@ -14,3 +14,5 @@ spec:
       kind: ClusterRoleBinding
     - group: rbac.authorization.k8s.io
       kind: ClusterRole
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition


### PR DESCRIPTION
The new ambassador chart now comes with CRD's. To allow these being applied by the Argocd ambassador project,  it has to be whitelisted.