### PR TITLE
Abstract argocd sources

### DIFF
--- a/seed/Chart.yaml
+++ b/seed/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v1
 name: seed
-version: 0.2.0
+version: 0.2.1

--- a/seed/templates/project.yaml
+++ b/seed/templates/project.yaml
@@ -7,6 +7,9 @@ spec:
   sourceRepos:
     - {{ .Values.repository }}
     - https://github.com/edgelevel/helm-charts.git
+    {{- range .Values.argocd.sourceRepos }}
+    - {{ . }}
+    {{- end }}
   destinations:
     - namespace: argocd
       server: https://kubernetes.default.svc

--- a/seed/values.yaml
+++ b/seed/values.yaml
@@ -1,4 +1,6 @@
 argocd:
   enabled: true
+  sourceRepos:
+    # - https://github.com/niqdev/do-k8s.git
 
 repository: https://github.com/edgelevel/gitops-k8s.git


### PR DESCRIPTION
This is to allow other root applications to be added to the `argocd` namespace. See [this](https://github.com/niqdev/do-k8s/blob/master/bootstrap/templates/applications-do.yaml#L13) example

I will release version `0.2.1` of the seed chart once merged