### PR TITLE
Optional ambassador mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ Observability is a source of truth for the actual running state of the system ri
 
 ## Argo CD
 
-Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes. It automates the deployment of the desired application states in the specified target environments. In this project Kubernetes manifests are specified as [helm](https://helm.sh/docs) charts.
+Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes. It automates the deployment of the desired application states in the specified target environments. In this project Kubernetes manifests are specified as [helm](https://helm.sh/docs) charts
 
-This guide will explain how to setup in few steps the whole infrastructure on DigitalOcean via GitOps and Argo CD. Note that it's not tightly coupled to any specific vendor and you should be able to easily port it on [EKS](https://aws.amazon.com/eks) or [GKE](https://cloud.google.com/kubernetes-engine) for example.
+This guide will explain how to setup in few steps the whole infrastructure via GitOps and Argo CD. Note that it's not tightly coupled to any specific vendor and you should be able to easily run it on [DigitalOcean](https://www.digitalocean.com/docs/kubernetes), [EKS](https://aws.amazon.com/eks) or [GKE](https://cloud.google.com/kubernetes-engine) for example
 
 <!--
 You need to embrace failures if you want to have the ability to heal and recover automatically in most of the situations. A useful pattern is to have an `initContainer` to solve dependencies between various resources. For example a Kafka application should check if topics have been properly created (ideally by an operator) before even start.
@@ -95,12 +95,12 @@ You need to embrace failures if you want to have the ability to heal and recover
 
 ![architecture](docs/img/architecture.png)
 
-Most of the steps have been kept manual on purpose, but they should be automated in a production enviroment.
+Most of the steps have been kept manual on purpose, but they should be automated in a production enviroment
 
 ### Prerequisites
 
-* Setup [guide](docs/setup.md)
-* Create a Kubernetes cluster on [DigitalOcean](https://www.digitalocean.com/docs/kubernetes)
+* [Setup](docs/setup.md) required tools
+* Create a Kubernetes cluster locally or with your favourite provider
 * Download the cluster configs and test connection
     ```bash
     export KUBECONFIG=~/.kube/<CLUSTER_NAME>-kubeconfig.yaml
@@ -163,6 +163,10 @@ kubectl get service ambassador -n ambassador
 [open|xdg-open] http://<EXTERNAL-IP>/httpbin/
 [open|xdg-open] http://<EXTERNAL-IP>/guestbook
 ```
+
+*Ambassador `Mapping` samples above are disabled by default because the recommended way is to use host-based routing which requires a domain*
+
+*TODO For a working example on DigitalOcean using [`external-dns`](https://github.com/helm/charts/tree/master/stable/external-dns) you can have a look at [niqdev/do-k8s](https://github.com/niqdev/do-k8s)*
 
 *TODO Service mesh*
 

--- a/applications/templates/ambassador/ambassador-mapping.yaml
+++ b/applications/templates/ambassador/ambassador-mapping.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ambassadorMapping.enabled }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -11,3 +12,4 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: ambassador
+{{- end }}

--- a/applications/templates/ambassador/project.yaml
+++ b/applications/templates/ambassador/project.yaml
@@ -6,7 +6,9 @@ metadata:
 spec:
   sourceRepos:
     - https://github.com/helm/charts.git
+    {{- if .Values.ambassadorMapping.enabled }}
     - https://github.com/edgelevel/gitops-k8s.git
+    {{- end }}
   destinations:
     - namespace: ambassador
       server: https://kubernetes.default.svc

--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -1,0 +1,2 @@
+ambassadorMapping:
+  enabled: false


### PR DESCRIPTION
After talking with the ambassador guys I got the feeling that the mapping I've created are not the one that you would generally use. I was trying to map also prometheus and grafana and trying to route based on the `Refer` header, but the urls were broken and the recommended way is to use host-based routing e.g. `grafana.mydomain.com` and not `<external-ip>/grafana` hence the mappings in this repo are only for sample purposes.
If I find a way to make it work for development purposes only I will create a new pr

I bought a domain and I will try to configure external DNS with DigitalOcean on my repo (which depends on the `seed` chart and the common infra) and at the same time I figured out that we should strive to keep this repo provider agnostic