### PR TITLE
Disable Ambassador by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ kubectl port-forward service/ambassador-admins 8877 -n ambassador
 [open|xdg-open] http://localhost:8877/ambassador/v0/diag
 ```
 
-*Ambassador `Mapping` samples above are [disabled](applications/values.yaml) by default because the recommended way is to use host-based routing which requires a domain*
+*Ambassador is [disabled](applications/values.yaml) by default because the recommended way is to use host-based routing which requires a domain*
 
 *TODO For a working example on DigitalOcean using [`external-dns`](https://github.com/helm/charts/tree/master/stable/external-dns) you can have a look at [niqdev/do-k8s](https://github.com/niqdev/do-k8s)*
 

--- a/applications/templates/ambassador/ambassador-mapping.yaml
+++ b/applications/templates/ambassador/ambassador-mapping.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ambassadorMapping.enabled }}
+{{- if .Values.ambassador.enabled }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/applications/templates/ambassador/ambassador.yaml
+++ b/applications/templates/ambassador/ambassador.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ambassador.enabled }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -15,3 +16,4 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: ambassador
+{{- end }}

--- a/applications/templates/ambassador/namespace.yaml
+++ b/applications/templates/ambassador/namespace.yaml
@@ -1,5 +1,7 @@
+{{- if .Values.ambassador.enabled }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: ambassador
+{{- end }}

--- a/applications/templates/ambassador/project.yaml
+++ b/applications/templates/ambassador/project.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ambassador.enabled }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
@@ -6,9 +7,7 @@ metadata:
 spec:
   sourceRepos:
     - https://github.com/helm/charts.git
-    {{- if .Values.ambassadorMapping.enabled }}
     - https://github.com/edgelevel/gitops-k8s.git
-    {{- end }}
   destinations:
     - namespace: ambassador
       server: https://kubernetes.default.svc
@@ -19,3 +18,4 @@ spec:
       kind: ClusterRole
     - group: apiextensions.k8s.io
       kind: CustomResourceDefinition
+{{- end }}

--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -1,2 +1,2 @@
-ambassadorMapping:
+ambassador:
   enabled: false


### PR DESCRIPTION
I'd leave the ambassador application in this repo as an example, but by default it should be disabled in order to allow customisations to integrate it with external-dns 