### PR TITLE
Fix kubernetes-dashboard rbac

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ For a working example on DigitalOcean using [`external-dns`](https://github.com/
 
 * [`kube-ops-view`](https://github.com/helm/charts/tree/master/stable/kube-ops-view) provides a read-only system dashboard for multiple k8s clusters
     ```bash
-    kubectl port-forward service/kube-ops-view-kube-ops-view -n observe 8004:80
+    kubectl port-forward service/kube-ops-view -n observe 8004:80
     ```
 
 *EFK stack for logging*
@@ -263,3 +263,10 @@ For a working example on DigitalOcean using [`external-dns`](https://github.com/
 * [ ] Add prometheus adapter for custom metrics that can be used by the [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale)
 * [ ] Verify/fix argocd version `version: 1.0.0-0` with `appVersion`
 * [ ] Explain how to test a branch - change target revision from the UI
+* [ ] TODO fix `alertmanager: error: unrecognized log format "<nil>", try --help`
+* [ ] TODO fix kubernetes-dashboard
+    ```
+    Storing encryption key in a secret
+    panic: secrets is forbidden: User "system:serviceaccount:kube-system:kubernetes-dashboard" cannot create resource "secrets
+    " in API group "" in the namespace "kube-system"
+    ```

--- a/README.md
+++ b/README.md
@@ -264,9 +264,3 @@ For a working example on DigitalOcean using [`external-dns`](https://github.com/
 * [ ] Verify/fix argocd version `version: 1.0.0-0` with `appVersion`
 * [ ] Explain how to test a branch - change target revision from the UI
 * [ ] TODO fix `alertmanager: error: unrecognized log format "<nil>", try --help`
-* [ ] TODO fix kubernetes-dashboard
-    ```
-    Storing encryption key in a secret
-    panic: secrets is forbidden: User "system:serviceaccount:kube-system:kubernetes-dashboard" cannot create resource "secrets
-    " in API group "" in the namespace "kube-system"
-    ```

--- a/applications/templates/kube-system/kubernetes-dashboard.yaml
+++ b/applications/templates/kube-system/kubernetes-dashboard.yaml
@@ -14,7 +14,7 @@ spec:
           value: "true" 
         - name: enableInsecureLogin
           value: "true" 
-        - name: rbac.clusterReadOnlyRole
+        - name: rbac.clusterAdminRole
           value: "true" 
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
The dashboard should never be exposed publicly in production

Fixes
```
Storing encryption key in a secret
    panic: secrets is forbidden: User "system:serviceaccount:kube-system:kubernetes-dashboard" cannot create resource "secrets
    " in API group "" in the namespace "kube-system"
```